### PR TITLE
conditional registration for the tile

### DIFF
--- a/src/plonesocial/core/browser/tiles/configure.zcml
+++ b/src/plonesocial/core/browser/tiles/configure.zcml
@@ -1,11 +1,13 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plonesocial.core">
 
   <include package="plone.tiles" file="meta.zcml" />
 
   <plone:tile
+      zcml:condition="not-installed plonesocial.microblog.browser.tiles"
       for="*"
       name="newpostbox.tile"
       title="A tile to add a new post"


### PR DESCRIPTION
Needed to start working on the tile for plonesocial.microblog.

The rationale is if we have the tile in plonesocial.microblog don't read this zcml snippet.

This will keep jenkins happy.

After we have this merged we will completely remove the tile registration.